### PR TITLE
Update _RCTD.py

### DIFF
--- a/tacco/tools/_RCTD.py
+++ b/tacco/tools/_RCTD.py
@@ -13,7 +13,7 @@ from .. import get
 from .. import preprocessing
 
 def _round_X(adata):
-    if scipy.sparse.issparse(adata.X.data):
+    if scipy.sparse.issparse(adata.X):
         adata.X.data = np.round(adata.X.data)
     else:
         adata.X = np.round(adata.X)


### PR DESCRIPTION
The test:

```python
scipy.sparse.issparse(adata.X.data) 
```

is `False` even if `type(adata.X)` is `anndata._core.views.SparseCSRMatrixView`. This caused `annotate_RCTD` to fail, with a strange 

> ValueError: could not convert integer scalar

thrown from scipy/sparse/_compressed.py:905, in _cs_matrix._set_arrayXarray_sparse(self, row, col, x). This error is triggered due to then running `adata.X = np.round(adata.X)`.

Please let me know, if there is something I'm missing here.